### PR TITLE
Canvis per calcular els preus per unitat de referència més fàcilment

### DIFF
--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -74,7 +74,8 @@ class BeesdooProduct(models.Model):
     display_unit = fields.Many2one("uom.uom")
     default_reference_unit = fields.Many2one("uom.uom")
     display_weight = fields.Float(
-        compute="_compute_display_weight", store=True
+        string="Net Quantity",
+        store=True
     )
 
     total_with_vat = fields.Float(
@@ -278,16 +279,9 @@ class BeesdooProduct(models.Model):
 
             if product.display_weight > 0:
                 product.total_with_vat_by_unit = (
-                    product.total_with_vat / product.weight
+                    product.total_with_vat / product.display_weight
                 )
 
-    @api.multi
-    @api.depends("weight", "display_unit")
-    def _compute_display_weight(self):
-        for product in self:
-            product.display_weight = (
-                product.weight * product.display_unit.factor
-            )
 
     @api.multi
     @api.constrains("display_unit", "default_reference_unit")

--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -37,11 +37,11 @@
                 <page string="Label">
                     <group>
                         <group name="label">
-                            <field name="total_with_vat" />
+                            <field name="total_with_vat" widget='monetary'/>
                             <field name="display_weight" />
                             <field name="display_unit" />
-                            <field name="default_reference_unit" />
-                            <field name="total_with_vat_by_unit" />
+                            <field name="default_reference_unit" />                            
+                            <field name="total_with_vat_by_unit" widget='monetary'/>
                             <field name="total_deposit" />
                         </group>
                         <group>


### PR DESCRIPTION
Fins ara, els preus per unitat de referència s'han estat calculant a mà i entrant al camp de Comentaris. Això ha portat a errors i a feina extra.

Veient el codi actual, hi ha uns camps preparats per a fer aquesta tasca (`display_weight`, `total_with_vat_by_unit`, `display_unit` i `default_reference_unit`).

El problema d'aquests camps és que `display_weight` depèn del camp `weight` de la pestanya "Inventari". Això fa que sigui poc intuïtiu de gestionar el tema del preu per unitat de referència.

El canvis proposats son:
- `display_weight`:  Deixa de ser computat, per tant també s'elimina la funció `_compute_display_weight`. Amb això el camp ja es pot editar directament.
- `total_with_vat_by_unit`: Es calcula a partir de `display_weight` i no de `weight`
- A la vista en qüestió, els camps `total_with_vat` i `total_with_vat_by_unit` els mostrem mitjançant widget monetary per millorar l'edició.